### PR TITLE
Feature/specify context mode in request body

### DIFF
--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -1388,6 +1388,7 @@ async def chat_completion(
                 )
                 else {}
             ),
+            "full_context": form_data.get("full_context", False)
         }
 
         request.state.metadata = metadata

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -659,7 +659,7 @@ async def chat_completion_files_handler(
                         r=request.app.state.config.RELEVANCE_THRESHOLD,
                         hybrid_bm25_weight=request.app.state.config.HYBRID_BM25_WEIGHT,
                         hybrid_search=request.app.state.config.ENABLE_RAG_HYBRID_SEARCH,
-                        full_context=request.app.state.config.RAG_FULL_CONTEXT,
+                        full_context=body["full_context"],
                     ),
                 )
         except Exception as e:


### PR DESCRIPTION
RAGのコンテキストモードをユーザーのAPIリクエストから指定できるようにします。

- `backend/open_webui/main.py`
  - `/api/chat/completions`で受け取ったリクエストのFormDataから`full_context`のBool値を`process_chat_payload`関数に渡します。`full_context`の初期値は`False`になります。 e1a3c2b3852a57f0f101864a3def6b279d6866f8
- `backend/open_webui/utils/middleware.py`
  - `process_chat_payload`関数から`chat_completion_files_handler`関数に渡された`full_context`を`get_sources_from_files`関数で使用してプロンプトを生成します。 97e4e2ed431b26f2eecd0e6030d86226af2d8245

このPRをマージすることで、管理者がRetrievalに設定するコンテキストモードは参照されなくなります。

フロントエンドから動作を検証する場合は、`src/lib/components/chat/Chat.svelte`ファイルで`generateOpenAIChatCompletion`関数の第二引数にあるオブジェクトリテラルに`full_context`プロパティを追加してください。