### PR TITLE
チャットUIでナレッジベースのドキュメントのコンテキストモードを変更できるようにする

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -470,7 +470,7 @@ def get_sources_from_files(
                 "documents": [[doc.get("content") for doc in file.get("docs")]],
                 "metadatas": [[doc.get("metadata") for doc in file.get("docs")]],
             }
-        elif file.get("context") == "full":
+        elif file.get("context") == "full" and file.get("type") != "collection":
             # Manual Full Mode Toggle
             query_result = {
                 "documents": [[file.get("file").get("data", {}).get("content")]],
@@ -546,7 +546,7 @@ def get_sources_from_files(
                 log.debug(f"skipping {file} as it has already been extracted")
                 continue
 
-            if full_context:
+            if full_context or file.get("context") == "full":
                 try:
                     query_result = get_all_items_from_collections(collection_names)
                 except Exception as e:

--- a/src/lib/components/chat/MessageInput/Commands.svelte
+++ b/src/lib/components/chat/MessageInput/Commands.svelte
@@ -14,6 +14,8 @@
 	import Knowledge from './Commands/Knowledge.svelte';
 	import Models from './Commands/Models.svelte';
 	import Spinner from '$lib/components/common/Spinner.svelte';
+	import { getFileById } from '$lib/apis/files';
+	import { WEBUI_API_BASE_URL } from '$lib/constants';
 
 	export let prompt = '';
 	export let files = [];
@@ -76,10 +78,16 @@
 						data: e.detail
 					});
 				}}
-				on:select={(e) => {
+				on:select={async (e) => {
 					console.log(e);
 					if (files.find((f) => f.id === e.detail.id)) {
 						return;
+					}
+
+					// knowledge base content selected
+					if (e.detail.collection) {
+						e.detail.file = await getFileById(localStorage.token, e.detail.id)
+						e.detail.url = `${WEBUI_API_BASE_URL}/files/${e.detail.id}`;
 					}
 
 					files = [

--- a/src/lib/components/chat/MessageInput/Commands.svelte
+++ b/src/lib/components/chat/MessageInput/Commands.svelte
@@ -84,8 +84,17 @@
 						return;
 					}
 
-					// knowledge base content selected
-					if (e.detail.collection) {
+					// knowledge base was selected as a collection
+					if (e.detail.type === "collection") {
+						e.detail.file = {
+							data: {
+								content: "This is a knowledge base."
+							}
+						}
+					}
+
+					// knowledge base content is selected as a file
+					if (e.detail.type === "file") {
 						e.detail.file = await getFileById(localStorage.token, e.detail.id)
 						e.detail.url = `${WEBUI_API_BASE_URL}/files/${e.detail.id}`;
 					}

--- a/src/lib/components/chat/MessageInput/Commands.svelte
+++ b/src/lib/components/chat/MessageInput/Commands.svelte
@@ -85,17 +85,17 @@
 					}
 
 					// knowledge base was selected as a collection
-					if (e.detail.type === "collection") {
+					if (e.detail.type === 'collection') {
 						e.detail.file = {
 							data: {
-								content: "This is a knowledge base."
+								content: 'This is a knowledge base.'
 							}
-						}
+						};
 					}
 
 					// knowledge base content is selected as a file
-					if (e.detail.type === "file") {
-						e.detail.file = await getFileById(localStorage.token, e.detail.id)
+					if (e.detail.type === 'file') {
+						e.detail.file = await getFileById(localStorage.token, e.detail.id);
 						e.detail.url = `${WEBUI_API_BASE_URL}/files/${e.detail.id}`;
 					}
 


### PR DESCRIPTION
## Summary

このPRは以下のIssueを解決します。
- #3

チャットの`#`サジェストから挿入した以下のファイルを、モーダルで表示できるようにします。
- ナレッジベース
- ナレッジベース内のファイル

<img width="600" alt="image" src="https://github.com/user-attachments/assets/bdd07f1c-0f70-4773-b910-08d03eb18947" />

左：ナレッジベースのモーダル　右：ナレッジベース内のファイルのモーダル
<img width="350" alt="image" src="https://github.com/user-attachments/assets/435a7676-4530-4318-87f0-bba1456ae3d4" /> <img width="350" alt="image" src="https://github.com/user-attachments/assets/cf8d9bfb-a629-4a3a-bd06-a5c7ea10cf87" />

モーダルに対応することで、以下の設定を変更することができます。
- フルコンテキストモードの切り替え

モーダル内のフルコンテキストモードの設定における処理の違いは以下の通りです。

種類 | フルコンテキスト | 処理内容
-- | -- | --
ナレッジベース | ❌ | ベクトルDBからナレッジベースのチャンクを埋め込む
ナレッジベース |✅ | ナレッジベースの内容をすべて埋め込む
ファイル | ❌ | ファイルの一部を埋め込む
ファイル | ✅ | ファイルの内容をすべて埋め込む

## Changed Files

- `src/lib/components/chat/MessageInput/Commands.svelte`
  - d6fd8e1315bd399279741c13e73ed10c73fe75dd
    - チャットに挿入されたナレッジベースファイルは、添付ファイルと互換性のあるオブジェクトになります。
    - ファイルをモーダル表示できるようになります。
    - ユーザーはコンテキストモードを指定できます。
  - 0cd33c5d311a1b31da39abcef6bbc4ab97122798
    - チャットに挿入されたナレッジベースは、添付ファイルと互換性のあるオブジェクトになります。
    - ナレッジベースをモーダル表示できるようになりました (コンテンツのプレビューなし) 。
    - ユーザーは、そのコンテキストモードを指定できます。
- `backend/open_webui/retrieval/utils.py`
  - aa461c4203d7528ab7ea9e4df525e5d840cbec11
    - チャットのコレクションのコンテキストモードに応じた条件分岐を追加します。
    - チャットに挿入されたコレクションがフルコンテキストモードの場合、通常のナレッジベースと同様に`get_doc`関数を実行します。
    - チャットに挿入されたコレクションがフルコンテキストモードでない場合、通常のナレッジベースと同様に`query_doc`関数を実行します。